### PR TITLE
changes to PHP Notifo_API

### DIFF
--- a/php/Notifo_API.php
+++ b/php/Notifo_API.php
@@ -16,27 +16,27 @@ class Notifo_API {
     $this->apiSecret = $apiSecret;
   }
 
-  /*
+  /**
    * function: sendNotification
    * @param: $params - an associative array of parameters to send to the Notifo API.
-   *                   These can be any of the following:
-   *                   to, msg, label, title, uri
-   *                   See https://api.notifo.com/ for more information
+   * These can be any of the following:
+   * to, msg, label, title, uri
+   * See https://api.notifo.com/ for more information
    */
   function sendNotification($params) {
     $validFields = array('to', 'msg', 'label', 'title', 'uri');
-    $data = array_intersect_key($data, array_flip($validFields));
-    return $this->sendRequest('send_notification', $data)
+    $params = array_intersect_key($params, array_flip($validFields));
+    return $this->sendRequest('send_notification', $params);
   } /* end function sendNotification */
 
-  /*
+  /**
    * function: subscribeUser
    * @param: $username - the username to subscribe to your Notifo service
-   *                     See https://api.notifo.com/ for more information
+   * See https://api.notifo.com/ for more information
    */
   function subscribeUser($username) {
     return $this->sendRequest('subscribe_user', array('username' => $username));
-  } /* end function subscribUser */
+  } /* end function subscribeUser */
 
 
   /**
@@ -45,19 +45,18 @@ class Notifo_API {
    * @param $data - array with arguments for remote method
    */
   protected function sendRequest($method, $data) {
-
     $ch = curl_init(self::API_ROOT.self::API_VER.'/'.$method);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
     curl_setopt($ch, CURLOPT_POST, true);
-    curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($data));
+    curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
     curl_setopt($ch, CURLOPT_USERPWD, $this->apiUsername.':'.$this->apiSecret);
     curl_setopt($ch, CURLOPT_HEADER, false);
-    curl_setopt($ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_0);
     $result = curl_exec($ch);
-    return $result
+    $result = json_decode($result, true);
+    return $result;
   } /* end function sendRequest */
 
-  // for backwards compatibility
+// for backwards compatibility
   function send_notification($params) { return json_encode($this->sendNotification($params)); }
   function subscribe_user($username) { return json_encode($this->subscribeUser($username)); }
   

--- a/php/Notifo_API.php
+++ b/php/Notifo_API.php
@@ -62,3 +62,5 @@ class Notifo_API {
   function subscribe_user($username) { return json_encode($this->subscribeUser($username)); }
   
 } /* end class Notifo_API */
+
+?>

--- a/php/Notifo_API.php
+++ b/php/Notifo_API.php
@@ -2,96 +2,63 @@
 
 class Notifo_API {
   
-  private $apiusername;
-  private $apisecret;
+  const API_ROOT = 'https://api.notifo.com/';
+  const API_VER = 'v1';
 
-  private $API_ROOT = "https://api.notifo.com/";
-  private $API_VER  = "v1";
-  private $API_SUBSCRIBE_USER_METHOD = "/subscribe_user";
-  private $API_SEND_NOTIFICATION_METHOD = "/send_notification";
+  protected $apiUsername;
+  protected $apiSecret;
 
-  /* class constructor */
-  function Notifo_API($apiusername = "", $apisecret = "") {
-    $this->apiusername = $apiusername;
-    $this->apisecret = $apisecret;
-  }
-
-  function set_apiusername($val) {
-    $this->apiusername = $val;
-  }
-
-  function set_apisecret($val) {
-    $this->apisecret = $val;
+  /**
+   * class constructor
+   */
+  function __construct($apiUsername, $apiSecret) {
+    $this->apiUsername = $apiUsername;
+    $this->apiSecret = $apiSecret;
   }
 
   /*
-   * function: send_notification
+   * function: sendNotification
    * @param: $params - an associative array of parameters to send to the Notifo API.
    *                   These can be any of the following:
    *                   to, msg, label, title, uri
    *                   See https://api.notifo.com/ for more information
    */
-  function send_notification($params) {
-    
-    $data = "";
-    $data .= "to=" . $params["to"];
-    $data .= "&msg=" . urlencode($params["msg"]);
-
-    if (isset($params["label"]) && $params["label"] != "") {
-      $data .= "&label=" . urlencode($params["label"]);
-    }
-
-    if (isset($params["title"]) && $params["title"] != "") {
-      $data .= "&title=" . urlencode($params["title"]);
-    }
-
-    if (isset($params["uri"]) && $params["uri"] != "") {
-      $data .= "&uri=" . urlencode($params["uri"]);
-    }
-
-    $api_url = $this->API_ROOT . $this->API_VER . $this->API_SEND_NOTIFICATION_METHOD;
-
-    $response = $this->send_request($api_url, "POST", $data);
-
-    return $response;
-  } /* end function api_send_notification */
+  function sendNotification($params) {
+    $validFields = array('to', 'msg', 'label', 'title', 'uri');
+    $data = array_intersect_key($data, array_flip($validFields));
+    return $this->sendRequest('send_notification', $data)
+  } /* end function sendNotification */
 
   /*
-   * function: subscribe_user
+   * function: subscribeUser
    * @param: $username - the username to subscribe to your Notifo service
    *                     See https://api.notifo.com/ for more information
    */
-  function subscribe_user($username) {
-    
-    $data = "username=" . $username;
+  function subscribeUser($username) {
+    return $this->sendRequest('subscribe_user', array('username' => $username));
+  } /* end function subscribUser */
 
-    $api_url = $this->API_ROOT . $this->API_VER . $this->API_SUBSCRIBE_USER_METHOD;
 
-    $response = $this->send_request($api_url, "POST", $data);
+  /**
+   * helper function to send the requests
+   * @param $method - name of remote method to call
+   * @param $data - array with arguments for remote method
+   */
+  protected function sendRequest($method, $data) {
 
-    return $response;
-  } /* end function api_subscribe_user */
-
-  /* helper function to send the requests */
-  function send_request($url, $type, $data) {
-
-    $ch = curl_init();
-    curl_setopt($ch, CURLOPT_URL, $url);
-    curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, FALSE);
-    curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, FALSE);
+    $ch = curl_init(self::API_ROOT.self::API_VER.'/'.$method);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-    curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
-    curl_setopt($ch, CURLOPT_USERPWD, $this->apiusername . ":" . $this->apisecret);
+    curl_setopt($ch, CURLOPT_POST, true);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($data));
+    curl_setopt($ch, CURLOPT_USERPWD, $this->apiUsername.':'.$this->apiSecret);
     curl_setopt($ch, CURLOPT_HEADER, false);
     curl_setopt($ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_0);
-    if ($type == "POST") {
-      curl_setopt($ch, CURLOPT_POST, 1);
-    }
-
     $result = curl_exec($ch);
+    return $result
+  } /* end function sendRequest */
 
-    return $result;
-
-  } /* end function send_request */
+  // for backwards compatibility
+  function send_notification($params) { return json_encode($this->sendNotification($params)); }
+  function subscribe_user($username) { return json_encode($this->subscribeUser($username)); }
   
 } /* end class Notifo_API */


### PR DESCRIPTION
Hi,

I did a lot of code cleanup, changed code to allow inheritance (protected variables, protected methods)
Removed a bug in send_notification (lack of $params['to'] caused a warning, but this key is not required)
Removed unneccessary options from CURL.
Changed naming convention to the one for PEAR (with backwards method wrappers for backwards compatibility).

Best regards,
Janusz
